### PR TITLE
fix: check renewed TTL is longer than secret TTL/2

### DIFF
--- a/dependency/vault_read.go
+++ b/dependency/vault_read.go
@@ -73,13 +73,13 @@ func (d *VaultReadQuery) Fetch(clients *ClientSet, opts *QueryOptions) (interfac
 		})
 
 		renewal, err := clients.Vault().Sys().Renew(d.secret.LeaseID, 0)
-		if err == nil {
+		if err == nil && renewal.LeaseDuration > (d.secret.LeaseDuration/2.0) {
 			log.Printf("[TRACE] %s: successfully renewed %s", d, d.secret.LeaseID)
 
 			secret := &Secret{
 				RequestID:     renewal.RequestID,
 				LeaseID:       renewal.LeaseID,
-				LeaseDuration: d.secret.LeaseDuration,
+				LeaseDuration: renewal.LeaseDuration,
 				Renewable:     renewal.Renewable,
 				Data:          d.secret.Data,
 			}


### PR DESCRIPTION
We ran into an issue with consul-template where a consul token
with max ttl 4h wasn't getting replaced, despite being invalid. The
token would expire, then 2 hours later consul-template would detect
it was old and get a new one. This is because consul-template assumes
that if it can renew and the renew call returns successfully, the token has
been renewed. However, as the vault docs[1] state:
> The requested increment is completely advisory. The backend in charge
> of the secret can choose to completely ignore it. For most secrets, the 
> backend does its best to respect the increment, but often limits it to ensure
> renewals every so often.
This means that our renew calls may be 'successful' but they do not
actually increase the TTL.

This change does 2 things:
1. It only considers a renewal a 'success' if the new lease duration is 
longer than 1/2 of the previous TTL.
2. It sets the secret TTL to be the TTL we got with the renewed token
as it might be different.

Together these changes prevent:
 - allowing a secret to expire before we try to renew it 
(by always using the renewed TTL to set our wait)
 - renewing a secret who has reached it's max TTL

[1] https://www.vaultproject.io/docs/concepts/lease.html#lease-durations-and-renewal